### PR TITLE
feat: Add GetProductVersionFeatureFlag function

### DIFF
--- a/examples/LexActivator.rb
+++ b/examples/LexActivator.rb
@@ -45,17 +45,6 @@ module LexActivator
            :state, [:char, BUFFER_SIZE_256],
            :country, [:char, BUFFER_SIZE_256],
            :postalCode, [:char, BUFFER_SIZE_256]
-
-    def to_hash
-      {
-        addressLine1: self[:addressLine1].to_s,
-        addressLine2: self[:addressLine2].to_s,
-        city: self[:city].to_s,
-        state: self[:state].to_s,
-        country: self[:country].to_s,
-        postalCode: self[:postalCode].to_s
-      }
-    end
   end
 
   class Metadata < FFI::Struct
@@ -69,19 +58,6 @@ module LexActivator
            :key, [:char, BUFFER_SIZE_256],
            :type, [:char, BUFFER_SIZE_256],
            :metadata, [Metadata, MAX_METADATA_SIZE] 
-
-    
-    def to_hash
-      {
-        allowedActivations: self[:allowedActivations],
-        allowedDeactivations: self[:allowedDeactivations],
-        key: self[:key].to_s.strip,
-        type: self[:type].to_s.strip,
-        metadata: self[:metadata].take_while { |m| !m[:key].to_s.strip.empty? }.map do |m|
-          { key: m[:key].to_s.strip, value: m[:value].to_s.strip }
-        end
-      }
-    end
   end
 
   # @method SetProductFile(file_path)
@@ -138,7 +114,7 @@ module LexActivator
   # @param [Integer] leaseDuration - value of the lease duration. A value of -1 indicates unlimited lease duration.
   # @return [Integer]
   # @scope class
-  attach_function :SetActivationLeaseDuration, [:int64], :int
+  attach_function :SetActivationLeaseDuration, :SetActivationLeaseDuration, [:int64], :int
 
   # @method SetActivationMetadata(key, value)
   # @param [String] key
@@ -269,7 +245,7 @@ module LexActivator
 
   # @method GetProductVersionFeatureFlag(name, enabled, data, length)
   # @param [String] name
-  # @param [Integer] enabled - Receives the value - 0 or 1
+  # @param [Integer] enabled - 0 or 1 indicating disabled or enabled for feature flag.
   # @param [String] data
   # @param [Integer] length
   # @return [Integer]
@@ -301,7 +277,7 @@ module LexActivator
   attach_function :GetLicenseKey, :GetLicenseKey, [:pointer, :uint], :int
 
   # @method GetLicenseExpiryDate(expiry_date)
-  # @param [FFI::Pointer(*Uint32T)] expiry_date
+  # @param [FFI::Pointer(*Uint32T)] expiry_date - A value of 0 indicates it has no expiry i.e a lifetime license.
   # @return [Integer]
   # @scope class
   attach_function :GetLicenseExpiryDate, :GetLicenseExpiryDate, [:pointer], :int

--- a/examples/LexActivator.rb
+++ b/examples/LexActivator.rb
@@ -46,7 +46,7 @@ module LexActivator
            :country, [:char, BUFFER_SIZE_256],
            :postalCode, [:char, BUFFER_SIZE_256]
 
-    def to_string
+    def to_hash
       {
         addressLine1: self[:addressLine1].to_s,
         addressLine2: self[:addressLine2].to_s,
@@ -71,7 +71,7 @@ module LexActivator
            :metadata, [Metadata, MAX_METADATA_SIZE] 
 
     
-    def to_string
+    def to_hash
       {
         allowedActivations: self[:allowedActivations],
         allowedDeactivations: self[:allowedDeactivations],
@@ -349,17 +349,17 @@ module LexActivator
   attach_function :GetLicenseUserMetadata, :GetLicenseUserMetadata, [:string, :pointer, :uint], :int
 
   # @method GetLicenseOrganizationAddress(organizationAddress)
-  # @param [String] organizationAddress
+  # @param [FFI::Pointer(OrganizationAddress)] organizationAddress
   # @return [Integer]
   # @scope class
-  attach_function :GetLicenseOrganizationAddress, [:pointer], :int
+  attach_function :GetLicenseOrganizationAddress, :GetLicenseOrganizationAddress, [:pointer], :int
 
-  # @method GetUserLicenses(UserLicense, length)
-  # @param [String] UserLicense
+  # @method GetUserLicenses(userLicense, length)
+  # @param [FFI::Pointer(UserLicense)] userLicense
   # @param [Integer] length
   # @return [Integer]
   # @scope class
-  attach_function :GetUserLicenses, [:pointer, :uint], :int
+  attach_function :GetUserLicenses, :GetUserLicenses, [:pointer, :uint], :int
 
   # @method GetLicenseOrganizationName(organizationName, length)
   # @param [String] organizationName

--- a/examples/LexActivator.rb
+++ b/examples/LexActivator.rb
@@ -114,7 +114,7 @@ module LexActivator
 
   # @method GetProductVersionFeatureFlag(name, enabled, data, length)
   # @param [String] name
-  # @param [String] enabled
+  # @param [Integer] enabled
   # @param [String] data
   # @param [Integer] length
   # @return [Integer]

--- a/examples/LexActivator.rb
+++ b/examples/LexActivator.rb
@@ -269,7 +269,7 @@ module LexActivator
 
   # @method GetProductVersionFeatureFlag(name, enabled, data, length)
   # @param [String] name
-  # @param [Integer] enabled
+  # @param [Integer] enabled - Receives the value - 0 or 1
   # @param [String] data
   # @param [Integer] length
   # @return [Integer]

--- a/examples/LexActivator.rb
+++ b/examples/LexActivator.rb
@@ -112,6 +112,15 @@ module LexActivator
   # @scope class
   attach_function :GetProductMetadata, :GetProductMetadata, [:string, :pointer, :uint], :int
 
+  # @method GetProductVersionFeatureFlag(name, enabled, data, length)
+  # @param [String] name
+  # @param [String] enabled
+  # @param [String] data
+  # @param [Integer] length
+  # @return [Integer]
+  # @scope class
+  attach_function :GetProductVersionFeatureFlag, :GetProductVersionFeatureFlag, [:string, :pointer, :pointer, :uint], :int
+
   # @method GetLicenseMetadata(key, value, length)
   # @param [String] key
   # @param [String] value

--- a/examples/LexStatusCodes.rb
+++ b/examples/LexStatusCodes.rb
@@ -181,7 +181,15 @@ module LexStatusCodes
 
   # CODE: LA_E_METER_ATTRIBUTE_USES_LIMIT_REACHED
   # MESSAGE: The meter attribute has reached it's usage limit.
-  LA_E_METER_ATTRIBUTE_USES_LIMIT_REACHED = 73
+  LA_E_METER_ATTRIBUTE_USES_LIMIT_REACHED = 73    
+  
+  # CODE: LA_E_PRODUCT_VERSION_NOT_LINKED
+  # MESSAGE: No product version is linked with the license.
+  LA_E_PRODUCT_VERSION_NOT_LINKED = 75,
+  
+  #  CODE: LA_E_FEATURE_FLAG_NOT_FOUND
+  # MESSAGE: The product version feature flag does not exist.
+  LA_E_FEATURE_FLAG_NOT_FOUND = 76,
 
   # CODE: LA_E_VM
   # MESSAGE: Application is being run inside a virtual machine / hypervisor,

--- a/examples/LexStatusCodes.rb
+++ b/examples/LexStatusCodes.rb
@@ -42,11 +42,6 @@ module LexStatusCodes
 
   LA_RELEASE_NO_UPDATE_AVAILABLE = 31
 
-  # CODE: LA_RELEASE_UPDATE_AVAILABLE_NOT_ALLOWED
-  # MESSAGE: The update available is not allowed for this license.
-
-  LA_RELEASE_UPDATE_AVAILABLE_NOT_ALLOWED = 32,
-
   # CODE: LA_E_FILE_PATH
   # MESSAGE: Invalid file path.
   LA_E_FILE_PATH = 40
@@ -264,4 +259,28 @@ module LexStatusCodes
   # CODE: LA_E_CLIENT
   # MESSAGE: Client error.
   LA_E_CLIENT = 92
+
+  # CODE: LA_E_LOGIN_TEMPORARILY_LOCKED
+  # MESSAGE: The user account has been temporarily locked for 5 mins due to 5 failed attempts.
+  LA_E_LOGIN_TEMPORARILY_LOCKED = 100,
+
+  # CODE: LA_E_AUTHENTICATION_ID_TOKEN_INVALID
+  # MESSAGE: Invalid authentication ID token.
+  LA_E_AUTHENTICATION_ID_TOKEN_INVALID = 101,
+
+  # CODE: LA_E_OIDC_SSO_NOT_ENABLED
+  # MESSAGE: OIDC SSO is not enabled.
+  LA_E_OIDC_SSO_NOT_ENABLED = 102,
+
+  # CODE: LA_E_USERS_LIMIT_REACHED
+  # MESSAGE: The allowed users for this account has reached its limit.
+  LA_E_USERS_LIMIT_REACHED = 103,
+
+  # CODE: LA_E_OS_USER
+  # MESSAGE: OS user has changed since activation and the license is user-locked.
+  LA_E_OS_USER = 104,
+
+  # CODE: LA_E_INVALID_PERMISSION_FLAG
+  # MESSAGE: Invalid permission flag.
+  LA_E_INVALID_PERMISSION_FLAG = 105,
 end

--- a/examples/LexStatusCodes.rb
+++ b/examples/LexStatusCodes.rb
@@ -185,27 +185,27 @@ module LexStatusCodes
   
   # CODE: LA_E_CUSTOM_FINGERPRINT_LENGTH
   # MESSAGE: Custom device fingerprint length is less than 64 characters or more than 256 characters.
-  LA_E_CUSTOM_FINGERPRINT_LENGTH = 74,
-
+  LA_E_CUSTOM_FINGERPRINT_LENGTH = 74
+  
   # CODE: LA_E_PRODUCT_VERSION_NOT_LINKED
   # MESSAGE: No product version is linked with the license.
-  LA_E_PRODUCT_VERSION_NOT_LINKED = 75,
+  LA_E_PRODUCT_VERSION_NOT_LINKED = 75
   
   #  CODE: LA_E_FEATURE_FLAG_NOT_FOUND
   # MESSAGE: The product version feature flag does not exist.
-  LA_E_FEATURE_FLAG_NOT_FOUND = 76,
+  LA_E_FEATURE_FLAG_NOT_FOUND = 76
   
   # CODE: LA_E_RELEASE_VERSION_NOT_ALLOWED
   # MESSAGE: The release version is not allowed.
-  LA_E_RELEASE_VERSION_NOT_ALLOWED = 77,  
+  LA_E_RELEASE_VERSION_NOT_ALLOWED = 77  
 
   # CODE: LA_E_RELEASE_PLATFORM_LENGTH
   # MESSAGE: Release platform length is more than 256 characters.
-  LA_E_RELEASE_PLATFORM_LENGTH = 78,
+  LA_E_RELEASE_PLATFORM_LENGTH = 78
 
   # CODE: LA_E_RELEASE_CHANNEL_LENGTH
   # MESSAGE: Release channel length is more than 256 characters.
-  LA_E_RELEASE_CHANNEL_LENGTH = 79,
+  LA_E_RELEASE_CHANNEL_LENGTH = 79
 
   # CODE: LA_E_VM
   # MESSAGE: Application is being run inside a virtual machine / hypervisor,
@@ -222,31 +222,31 @@ module LexStatusCodes
   
   # CODE: LA_E_CONTAINER
   # MESSAGE: Application is being run inside a container and activation has been disallowed in the container.
-  LA_E_CONTAINER = 83,
+  LA_E_CONTAINER = 83
   
   # CODE: LA_E_RELEASE_VERSION
   # MESSAGE: Invalid release version. Make sure the release version uses the following formats: x.x, x.x.x, x.x.x.x (where x is a number).
-  LA_E_RELEASE_VERSION = 84,
+  LA_E_RELEASE_VERSION = 84
 
   # CODE: LA_E_RELEASE_PLATFORM
   # MESSAGE: Release platform not set.
-  LA_E_RELEASE_PLATFORM = 85,
+  LA_E_RELEASE_PLATFORM = 85
 
   # CODE: LA_E_RELEASE_CHANNEL
   # MESSAGE: Release channel not set.
-  LA_E_RELEASE_CHANNEL = 86,
+  LA_E_RELEASE_CHANNEL = 86
 
   # CODE: LA_E_USER_NOT_AUTHENTICATED
   # MESSAGE: The user is not authenticated.
-  LA_E_USER_NOT_AUTHENTICATED = 87,
+  LA_E_USER_NOT_AUTHENTICATED = 87
 
   # CODE: LA_E_TWO_FACTOR_AUTHENTICATION_CODE_MISSING
   # MESSAGE: The two-factor authentication code for the user authentication is missing.
-  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_MISSING = 88,
+  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_MISSING = 88
 
   # CODE: LA_E_TWO_FACTOR_AUTHENTICATION_CODE_INVALID
   # MESSAGE: The two-factor authentication code provided by the user is invalid.
-  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_INVALID = 89,
+  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_INVALID = 89
 
   # CODE: LA_E_RATE_LIMIT
   # MESSAGE: Rate limit for API has reached, try again later.
@@ -262,25 +262,25 @@ module LexStatusCodes
 
   # CODE: LA_E_LOGIN_TEMPORARILY_LOCKED
   # MESSAGE: The user account has been temporarily locked for 5 mins due to 5 failed attempts.
-  LA_E_LOGIN_TEMPORARILY_LOCKED = 100,
+  LA_E_LOGIN_TEMPORARILY_LOCKED = 100
 
   # CODE: LA_E_AUTHENTICATION_ID_TOKEN_INVALID
   # MESSAGE: Invalid authentication ID token.
-  LA_E_AUTHENTICATION_ID_TOKEN_INVALID = 101,
+  LA_E_AUTHENTICATION_ID_TOKEN_INVALID = 101
 
   # CODE: LA_E_OIDC_SSO_NOT_ENABLED
   # MESSAGE: OIDC SSO is not enabled.
-  LA_E_OIDC_SSO_NOT_ENABLED = 102,
+  LA_E_OIDC_SSO_NOT_ENABLED = 102
 
   # CODE: LA_E_USERS_LIMIT_REACHED
   # MESSAGE: The allowed users for this account has reached its limit.
-  LA_E_USERS_LIMIT_REACHED = 103,
+  LA_E_USERS_LIMIT_REACHED = 103
 
   # CODE: LA_E_OS_USER
   # MESSAGE: OS user has changed since activation and the license is user-locked.
-  LA_E_OS_USER = 104,
+  LA_E_OS_USER = 104
 
   # CODE: LA_E_INVALID_PERMISSION_FLAG
   # MESSAGE: Invalid permission flag.
-  LA_E_INVALID_PERMISSION_FLAG = 105,
+  LA_E_INVALID_PERMISSION_FLAG = 105
 end

--- a/examples/LexStatusCodes.rb
+++ b/examples/LexStatusCodes.rb
@@ -42,6 +42,11 @@ module LexStatusCodes
 
   LA_RELEASE_NO_UPDATE_AVAILABLE = 31
 
+  # CODE: LA_RELEASE_UPDATE_AVAILABLE_NOT_ALLOWED
+  # MESSAGE: The update available is not allowed for this license.
+
+  LA_RELEASE_UPDATE_AVAILABLE_NOT_ALLOWED = 32,
+
   # CODE: LA_E_FILE_PATH
   # MESSAGE: Invalid file path.
   LA_E_FILE_PATH = 40
@@ -183,6 +188,10 @@ module LexStatusCodes
   # MESSAGE: The meter attribute has reached it's usage limit.
   LA_E_METER_ATTRIBUTE_USES_LIMIT_REACHED = 73    
   
+  # CODE: LA_E_CUSTOM_FINGERPRINT_LENGTH
+  # MESSAGE: Custom device fingerprint length is less than 64 characters or more than 256 characters.
+  LA_E_CUSTOM_FINGERPRINT_LENGTH = 74,
+
   # CODE: LA_E_PRODUCT_VERSION_NOT_LINKED
   # MESSAGE: No product version is linked with the license.
   LA_E_PRODUCT_VERSION_NOT_LINKED = 75,
@@ -190,6 +199,18 @@ module LexStatusCodes
   #  CODE: LA_E_FEATURE_FLAG_NOT_FOUND
   # MESSAGE: The product version feature flag does not exist.
   LA_E_FEATURE_FLAG_NOT_FOUND = 76,
+  
+  # CODE: LA_E_RELEASE_VERSION_NOT_ALLOWED
+  # MESSAGE: The release version is not allowed.
+  LA_E_RELEASE_VERSION_NOT_ALLOWED = 77,  
+
+  # CODE: LA_E_RELEASE_PLATFORM_LENGTH
+  # MESSAGE: Release platform length is more than 256 characters.
+  LA_E_RELEASE_PLATFORM_LENGTH = 78,
+
+  # CODE: LA_E_RELEASE_CHANNEL_LENGTH
+  # MESSAGE: Release channel length is more than 256 characters.
+  LA_E_RELEASE_CHANNEL_LENGTH = 79,
 
   # CODE: LA_E_VM
   # MESSAGE: Application is being run inside a virtual machine / hypervisor,
@@ -203,6 +224,34 @@ module LexStatusCodes
   # CODE: LA_E_IP
   # MESSAGE: IP address is not allowed.
   LA_E_IP = 82
+  
+  # CODE: LA_E_CONTAINER
+  # MESSAGE: Application is being run inside a container and activation has been disallowed in the container.
+  LA_E_CONTAINER = 83,
+  
+  # CODE: LA_E_RELEASE_VERSION
+  # MESSAGE: Invalid release version. Make sure the release version uses the following formats: x.x, x.x.x, x.x.x.x (where x is a number).
+  LA_E_RELEASE_VERSION = 84,
+
+  # CODE: LA_E_RELEASE_PLATFORM
+  # MESSAGE: Release platform not set.
+  LA_E_RELEASE_PLATFORM = 85,
+
+  # CODE: LA_E_RELEASE_CHANNEL
+  # MESSAGE: Release channel not set.
+  LA_E_RELEASE_CHANNEL = 86,
+
+  # CODE: LA_E_USER_NOT_AUTHENTICATED
+  # MESSAGE: The user is not authenticated.
+  LA_E_USER_NOT_AUTHENTICATED = 87,
+
+  # CODE: LA_E_TWO_FACTOR_AUTHENTICATION_CODE_MISSING
+  # MESSAGE: The two-factor authentication code for the user authentication is missing.
+  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_MISSING = 88,
+
+  # CODE: LA_E_TWO_FACTOR_AUTHENTICATION_CODE_INVALID
+  # MESSAGE: The two-factor authentication code provided by the user is invalid.
+  LA_E_TWO_FACTOR_AUTHENTICATION_CODE_INVALID = 89,
 
   # CODE: LA_E_RATE_LIMIT
   # MESSAGE: Rate limit for API has reached, try again later.


### PR DESCRIPTION
This commit adds the GetProductVersionFeatureFlag function to the LexActivator module. This function allows retrieving the feature flag status for a specific product version. It takes the name of the feature flag, a pointer to store the enabled status, a pointer to store the data associated with the feature flag, and the length of the data.